### PR TITLE
Print dependencies and dev-dependencies

### DIFF
--- a/lib/builders/addon.js
+++ b/lib/builders/addon.js
@@ -48,6 +48,12 @@ AddonBuilder.prototype = {
       });
     }
     console.log('');
+  },
+
+  printDependencies: function() {
+    console.log('   Dependencies: (' + chalk.bold(this.addon.dependencies.length) + ') ' + this.addon.dependencies.join(' '));
+    console.log('');
+    console.log('   devDependencies: (' + chalk.bold(this.addon.devDependencies.length) + ') ' + this.addon.devDependencies.join(' '));
   }
 };
 

--- a/lib/commands/inspect.js
+++ b/lib/commands/inspect.js
@@ -58,6 +58,7 @@ module.exports = Command.extend({
       builder.printMetadata(metadata);
       builder.printBlueprints(new BlueprintCollection(metadata));
       builder.printCommands(new CommandCollection(metadata));
+      builder.printDependencies();
     }
   }
 });

--- a/lib/models/addon-metadata.js
+++ b/lib/models/addon-metadata.js
@@ -15,6 +15,8 @@ function AddonMetadata(emberAddon, path) {
   this.author = null;
   this.license = null;
   this.isInvalid = false; // TRUE if we couldn't read metadata
+  this.devDependencies = [];
+  this.dependencies = [];
 }
 
 AddonMetadata.prototype = {
@@ -52,6 +54,16 @@ AddonMetadata.prototype = {
       }
 
       this.license = meta.license;
+
+      if (meta.dependencies) {
+        this.dependencies = Object.keys(meta.dependencies);
+        this.dependencies.sort();
+      }
+
+      if (meta.devDependencies) {
+        this.devDependencies = Object.keys(meta.devDependencies);
+        this.devDependencies.sort();
+      }
     } catch(e) {
       // file doesn't exist
       if (!/Cannot find module/.test(e.toString())) {


### PR DESCRIPTION
Show a list of NPM dependencies and dev-dependencies. Fixes #9

Example

```
$ ember inspect ember-cli-jshint
JSHint support for ember-cli projects

      version: 1.0.4
     homepage: https://github.com/ember-cli/ember-cli-jshint
         bugs: https://github.com/ember-cli/ember-cli-jshint/issues
   repository: git+https://github.com/ember-cli/ember-cli-jshint.git
       author: Jake Craige (jake@poeticsystems.com)
      license: MIT

   Blueprints: none

   Commands: none

   Dependencies: (1) broccoli-jshint

   devDependencies: (5) ember-cli ember-cli-htmlbars ember-resolver ember-try loader.js
```